### PR TITLE
fix compile for pybind11 2.4.3 on macOS

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -136,7 +136,7 @@ class BuildExt(build_ext):
     }
 
     if sys.platform == 'darwin':
-        darwin_opts = ['-stdlib=libc++', '-mmacosx-version-min=10.12']
+        darwin_opts = ['-stdlib=libc++', '-mmacosx-version-min=10.14']
         c_opts['unix'] += darwin_opts
         l_opts['unix'] += darwin_opts
 


### PR DESCRIPTION
This fixes building on macOS 10.15.2 with a current pybind  2.4.3 for me. In short, pybind needs `mmacosx-version-min=10.14`. The error is here:

```
building 'skgeom._skgeom' extension
    creating build
    creating build/temp.macosx-10.7-x86_64-3.7
    creating build/temp.macosx-10.7-x86_64-3.7/src
    gcc -Wno-unused-result -Wsign-compare -Wunreachable-code -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -I/Users/offline/miniconda3/envs/nteract/include -arch x86_64 -I/Users/offline/miniconda3/envs/nteract/include -arch x86_64 -I./include/ -I/Users/offline/miniconda3/envs/nteract/include -I/Users/offline/miniconda3/envs/nteract/include -I/Users/offline/miniconda3/envs/nteract/include -I/Users/offline/miniconda3/envs/nteract/include/python3.7m -c src/skgeom.cpp -o build/temp.macosx-10.7-x86_64-3.7/src/skgeom.o -stdlib=libc++ -mmacosx-version-min=10.12 -DVERSION_INFO="0.1.0" -std=c++17 -fvisibility=hidden
    In file included from src/skgeom.cpp:10:
    In file included from /Users/offline/miniconda3/envs/nteract/include/python3.7m/pybind11/pybind11.h:44:
    In file included from /Users/offline/miniconda3/envs/nteract/include/python3.7m/pybind11/attr.h:13:
    /Users/offline/miniconda3/envs/nteract/include/python3.7m/pybind11/cast.h:579:34: error: aligned allocation function of type 'void *(std::size_t, std::align_val_t)' is only available on macOS 10.14 or newer
                            vptr = ::operator new(type->type_size,
                                     ^
    /Users/offline/miniconda3/envs/nteract/include/python3.7m/pybind11/cast.h:579:34: note: if you supply your own aligned allocation functions, use -faligned-allocation to silence this diagnostic
    1 error generated.
    error: command 'gcc' failed with exit status 1
```

I believe it's best to just change 10.12 to 10.14.