### PR TITLE
fix compile for CGAL >= 5.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, Extension
 from setuptools.command.build_ext import build_ext
-import sys, os, glob
+import sys, os, glob, re
 import setuptools
 
 
@@ -61,6 +61,20 @@ if os.getenv('CONDA_PREFIX') or os.getenv('MINICONDAPATH'):
         print("Names of adjusted CGAL libs: ", adjusted_cgal_libs)
 
     include_dirs.insert(1, os.path.join(prefix, 'include'))
+
+cgal_version = None
+if os.path.exists('/usr/local/include/CGAL/version.h'):
+    with open('/usr/local/include/CGAL/version.h', 'r') as f:
+        m = re.search(r'#define\s+CGAL_VERSION\s+(.+)', f.read())
+        if m:
+            cgal_version = tuple(map(int, m.group(1).split('.')))
+
+if cgal_version:
+    print("Found CGAL version: " + '.'.join(map(str, cgal_version)))
+    if cgal_version >= (5, 0):
+        cgal_libs = []  # header only now.
+else:
+    print("Could not determine CGAL version.")
 
 ext_modules = [
     Extension(


### PR DESCRIPTION
scikit-geometry does not compile with a current vanilla CGAL 5 on macOS (using `cmake` and `make install` globally) because it lacks libraries. As far as I understand, CGAL became header only with CGAL 5.0.

This PR proposes a fix by checking if CGAL >= 5.0, and if so, omits the library flags, which causes trouble.

The version check for CGAL is hacky, by checking for `/usr/local/include/CGAL/version.h`. It should work for standard installations on macOS and Unix though. A better fix might involve running a compiler on "#include <CGAL/version.h>" and checking the result, but I didn't find a good solution for doing this inside `setup.py` at the right moment of installation.

Here's the original error this PR fixes: 

```
creating build/lib.macosx-10.7-x86_64-3.7
  creating build/lib.macosx-10.7-x86_64-3.7/skgeom
  g++ -bundle -undefined dynamic_lookup -L/Users/offline/miniconda3/envs/nteract/lib -arch x86_64 -L/Users/offline/miniconda3/envs/nteract/lib -arch x86_64 -arch x86_64 build/temp.macosx-10.7-x86_64-3.7/src/skgeom.o build/temp.macosx-10.7-x86_64-3.7/src/kernel.o build/temp.macosx-10.7-x86_64-3.7/src/polygon.o build/temp.macosx-10.7-x86_64-3.7/src/global_functions.o build/temp.macosx-10.7-x86_64-3.7/src/boolean.o build/temp.macosx-10.7-x86_64-3.7/src/convex_hull.o build/temp.macosx-10.7-x86_64-3.7/src/visibility.o build/temp.macosx-10.7-x86_64-3.7/src/arrangement.o build/temp.macosx-10.7-x86_64-3.7/src/principal_component_analysis.o build/temp.macosx-10.7-x86_64-3.7/src/minkowski.o build/temp.macosx-10.7-x86_64-3.7/src/polyhedron.o build/temp.macosx-10.7-x86_64-3.7/src/aabb_tree.o build/temp.macosx-10.7-x86_64-3.7/src/voronoi_delaunay.o build/temp.macosx-10.7-x86_64-3.7/src/optimal_transport.o -lCGAL -lCGAL_Core -lmpfr -lgmp -lboost_thread -lboost_atomic -lboost_system -lboost_date_time -lboost_chrono -o build/lib.macosx-10.7-x86_64-3.7/skgeom/_skgeom.cpython-37m-darwin.so -stdlib=libc++ -mmacosx-version-min=10.14
  ld: library not found for -lCGAL
  clang: error: linker command failed with exit code 1 (use -v to see invocation)
  error: command 'g++' failed with exit status 1
  ----------------------------------------
  ERROR: Failed building wheel for skgeom
```
