### PR TITLE
fix a small warning on macOS during setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -101,11 +101,12 @@ def has_flag(compiler, flagname):
     """Return a boolean indicating whether a flag name is supported on
     the specified compiler.
     """
+    extra = ['-stdlib=libc++'] if sys.platform == 'darwin' else []
     import tempfile
     with tempfile.NamedTemporaryFile('w', suffix='.cpp') as f:
         f.write('int main (int argc, char **argv) { return 0; }')
         try:
-            compiler.compile([f.name], extra_postargs=[flagname])
+            compiler.compile([f.name], extra_postargs=[flagname] + extra)
         except setuptools.distutils.errors.CompileError:
             return False
     return True


### PR DESCRIPTION
Fixes this warning on macOS during installation:

```
gcc -Wno-unused-result -Wsign-compare -Wunreachable-code -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -I/Users/offline/miniconda3/envs/nteract/include -arch x86_64 -I/Users/offline/miniconda3/envs/nteract/include -arch x86_64 -I/Users/offline/miniconda3/envs/nteract/include/python3.7m -c /var/folders/8g/f04p41wd0rvgd07gz_vcz80c0000gr/T/tmpm1lmp5xa.cpp -o var/folders/8g/f04p41wd0rvgd07gz_vcz80c0000gr/T/tmpm1lmp5xa.o -std=c++17
warning: include path for stdlibc++ headers not found; pass '-stdlib=libc++' on the command line to use the libc++ standard library instead [-Wstdlibcxx-not-found]
1 warning generated.
```