### PR TITLE
fix boost-mt libs on macOS

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -76,6 +76,11 @@ if cgal_version:
 else:
     print("Could not determine CGAL version.")
 
+if sys.platform == 'darwin' and glob.glob('/usr/local/lib/libboost*-mt*'):
+    boost_mt = True
+else:
+    boost_mt = False
+
 ext_modules = [
     Extension(
         'skgeom._skgeom',
@@ -101,6 +106,8 @@ ext_modules = [
                    'gmp', 
                    'boost_thread',
                    'boost_atomic',
+                   'boost_thread-mt' if boost_mt else 'boost_thread',
+                   'boost_atomic-mt' if boost_mt else 'boost_atomic',
                    'boost_system',
                    'boost_date_time',
                    'boost_chrono'],


### PR DESCRIPTION
Fixes another compile issue on macOS using a default global boost installation (via `brew install boost`).

In this case, `boost_thread` and `boost_atomic` do not exist, only their variants `boost_thread-mt` and `boost_atomic-mt`. Since this is the default homebrew installation, I believe this should be supported here.