### PR TITLE
fix proper installation of python portion of package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -180,4 +180,5 @@ setup(
     setup_requires=['pybind11>=2.3'],
     cmdclass={'build_ext': BuildExt},
     zip_safe=False,
+    packages=['skgeom'],
 )


### PR DESCRIPTION
Fixes another problem I ran into when installing this on macOS. Without this PR, the python sources do not get installed, and thus what you see is this:

```
>>> import skgeom as sg
>>> a = sg.Point2(5, 3)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: module 'skgeom' has no attribute 'Point2'
>>> dir(sg)
['__doc__', '__file__', '__loader__', '__name__', '__package__', '__path__', '__spec__']
>>> import _skgeom
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ModuleNotFoundError: No module named '_skgeom'
>>> import skgeom._skgeom
>>> import skgeom._skgeom as sg
>>> sg.Point2(5, 3)
PointC2(5, 3)
>>> 
```