### PR TITLE
easier construction of Polygon, PolygonWithHoles

### DIFF
--- a/src/polygon.cpp
+++ b/src/polygon.cpp
@@ -1,6 +1,8 @@
 #include "skgeom.hpp"
 #include "funcs.hpp"
 
+#include <pybind11/numpy.h>
+
 std::vector<Segment_2> get_edges(Polygon_2 p) {
 	auto seg_begin = p.edges_begin();
 	std::vector<Segment_2> result;
@@ -18,12 +20,29 @@ Point_2 centroid(Polygon_2& poly) {
     return CGAL::centroid(poly.vertices_begin(), poly.vertices_end(), CGAL::Dimension_tag<0>());
 }
 
+void build_polygon_from_vertices(Polygon_2& poly, const py::array_t<double>& vertices) {
+    auto r = vertices.unchecked<2>();
+    if (r.shape(1) != 2) {
+        throw std::runtime_error("vertices need to be 2 dimensional");
+    }
+    const ssize_t n = r.shape(0);
+
+    for (ssize_t i = 0; i < n; i++) {
+        poly.push_back(Point_2(r(i, 0), r(i, 1)));
+    } 
+}
+
 void init_polygon(py::module &m) {
 
     py::class_<Polygon_2>(m, "Polygon")
         .def(py::init<>())
 	    .def(py::init([](const std::vector<Point_2>& vertices) {
             return new Polygon_2(vertices.begin(), vertices.end());
+        }))
+	    .def(py::init([](const py::array_t<double> &vertices) {
+            Polygon_2 *polygon = new Polygon_2;
+            build_polygon_from_vertices(*polygon, vertices);
+            return polygon;
         }))
         .def("push_back", &Polygon_2::push_back)
         .def("append", &Polygon_2::push_back)
@@ -49,6 +68,16 @@ void init_polygon(py::module &m) {
     py::class_<Polygon_with_holes_2>(m, "PolygonWithHoles")
         .def(py::init([](const Polygon_2& outer, const std::vector<Polygon_2>& holes) {
             return new Polygon_with_holes_2(outer, holes.begin(), holes.end());
+        }))
+        .def(py::init([](const py::array_t<double>& outer, const py::list holes) {
+            Polygon_2 outer_poly;
+            build_polygon_from_vertices(outer_poly, outer);
+            std::vector<Polygon_2> holes_poly(holes.size());
+            for (size_t i = 0; i < holes.size(); i++) {
+                build_polygon_from_vertices(
+                    holes_poly[i], holes[i].cast<py::array_t<double>>());
+            }
+            return new Polygon_with_holes_2(outer_poly, holes_poly.begin(), holes_poly.end());
         }))
         .def("outer_boundary", py::overload_cast<>(&Polygon_with_holes_2::outer_boundary))
         .def_property_readonly("holes", [](const Polygon_with_holes_2& p) {


### PR DESCRIPTION
Allows

```
polygon = sg.Polygon([[0, 0], [1, 0], [1, 1], [0, 1]])
```

instead of:
```
polygon = sg.Polygon([sg.Point2(0, 0), sg.Point2(1, 0), sg.Point2(1, 1), sg.Point2(0, 1)])
```

Also:
```
polygon = sg.PolygonWithHoles(
    [[0, 0], [1, 0], [1, 1], [0, 1]],
    [
        [
            [0.1, 0.2],
            [0.2, 0.2],
            [0.1, 0.4]
        ],
        [
            [0.3, 0.2],
            [0.4, 0.2],
            [0.2, 0.3]
        ]
    ])
```

yields

```

Polygon_with_holes_2(
Boundary(
Polygon_2(
  PointC2(0, 0)
  PointC2(1, 0)
  PointC2(1, 1)
  PointC2(0, 1)
)

Holes
2
 Polygon_2(
  PointC2(0.1, 0.2)
  PointC2(0.2, 0.2)
  PointC2(0.1, 0.4)
)

 Polygon_2(
  PointC2(0.3, 0.2)
  PointC2(0.4, 0.2)
  PointC2(0.2, 0.3)
)

)
```

I'm not comfy with my `new` allocation, but I copied your code for now (see https://github.com/scikit-geometry/scikit-geometry/issues/23).