### PR TITLE
draw polygons with holes with a single matplotlib patch

### DIFF
--- a/skgeom/draw.py
+++ b/skgeom/draw.py
@@ -253,31 +253,25 @@ def draw_polygon(
 ):
     fig, ax = plt.gcf(), plt.gca()
     vertices = to_list_of_tuples(polygon.vertices) + [(0, 0)]
-    polygon_length = 0
 
-    for v in polygon.vertices:
-        polygon_length += 1
-        if plot_vertices:
+    if plot_vertices:
+        for v in polygon.vertices:
             draw_point(v, color=point_color)
 
-    codes = [Path.MOVETO] + [Path.LINETO] * (polygon_length - 1) + [Path.CLOSEPOLY]
-    path = Path(vertices, codes)
-    plt.gca().add_patch(patches.PathPatch(path, facecolor=facecolor, lw=line_width))
+    codes = [Path.MOVETO] + [Path.LINETO] * (len(vertices) - 2) + [Path.CLOSEPOLY]
 
     if polygon_with_holes:
         for hole in polygon_with_holes.holes:
-            hole_length = 0
-            vertices = to_list_of_tuples(hole.vertices) + [(0, 0)]
-            for v in hole.vertices:
-                hole_length += 1
-                if plot_vertices:
+            if plot_vertices:
+                for v in hole.vertices:
                     draw_point(v, color=point_color)
 
-            codes = [Path.MOVETO] + [Path.LINETO] * (hole_length - 1) + [Path.CLOSEPOLY]
-            path = Path(vertices, codes)
-            plt.gca().add_patch(
-                patches.PathPatch(path, facecolor="white", lw=line_width)
-            )
+            hole_vertices = list(to_list_of_tuples(hole.vertices)) + [(0, 0)]
+            codes.extend([Path.MOVETO] + [Path.LINETO] * (len(hole_vertices) - 2) + [Path.CLOSEPOLY])
+            vertices.extend(hole_vertices)
+
+    path = Path(vertices, codes)
+    plt.gca().add_patch(patches.PathPatch(path, facecolor=facecolor, lw=line_width))
 
     plt.gca().relim()
     plt.gca().autoscale_view()


### PR DESCRIPTION
At the moment, drawing polygons with holes through `draw_polygon` will draw hole patches in a second pass on top the outer boundary.

This is correct, given that "The holes must be contained inside the outer boundary, and the polygons representing the holes must be simple and pairwise disjoint, except perhaps at the vertices." (https://doc.cgal.org/latest/Polygon/classGeneralPolygonWithHoles__2.html).

Still, I feel it would be beneficial to draw just one matplotlib patch, since it would allow for transparency. This is what this PR is about. Results for correct holes are as before:

<img width="527" alt="Bildschirmfoto 2020-01-12 um 14 18 15" src="https://user-images.githubusercontent.com/11859538/72219464-be01e700-3546-11ea-84bf-31e4b8259fb5.png">

# Illegal definitions of polygon holes

Both variants shouldn't matter, since the polygon definitions are wrong in both cases.

Example of the drawing at the moment:

<img width="947" alt="overlay" src="https://user-images.githubusercontent.com/11859538/72219319-2223ab80-3545-11ea-85f7-8ee98c8c07a2.png">

Example of the new drawing:

<img width="766" alt="Bildschirmfoto 2020-01-12 um 14 18 08" src="https://user-images.githubusercontent.com/11859538/72219470-c9551280-3546-11ea-9706-9d305365f974.png">
