### PR TITLE
add CGAL_DEBUG to enable assertions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -176,8 +176,10 @@ class BuildExt(build_ext):
             opts.append(cpp_flag(self.compiler))
             if has_flag(self.compiler, '-fvisibility=hidden'):
                 opts.append('-fvisibility=hidden')
+            opts.append('-DCGAL_DEBUG=1')
         elif ct == 'msvc':
             opts.append('/DVERSION_INFO=\\"%s\\"' % self.distribution.get_version())
+            opts.append('/DCGAL_DEBUG=1')
         for ext in self.extensions:
             ext.extra_compile_args = opts
             ext.extra_link_args = link_opts


### PR DESCRIPTION
CGAL uses internal preconditions and assertions to prevent inconsistent states. In our current build these are not enabled. Problem is: this can lead to crashes.

The following code crashes `master` with a segmentation fault:

```
import skgeom as sg
sg.PolygonSet([
    sg.Polygon([
        [-0.253495, -0.0304946],
        [0.315702, 0.208666],
        [0.482571, 0.445271],
        [-0.253495, -0.0304946]])])
```

Running the same thing in C++ with the default CGAL settings produces a message, not a crash.

By adding `CGAL_DEBUG` we achieve the same thing:

<img width="832" alt="exception" src="https://user-images.githubusercontent.com/11859538/72464162-0fbfa100-37d5-11ea-969a-d930b4e60088.png">


