### PR TITLE
return vertices as numpy array via new method

### DIFF
--- a/docs/source/polygon.ipynb
+++ b/docs/source/polygon.ipynb
@@ -90,6 +90,55 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Likewise, you can access a Polygon's vertices as either a list of `Point2`s or as a numpy array:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[PointC2(0, 0), PointC2(0, 3), PointC2(3, 3)]"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "list(poly.vertices)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([[0., 0.],\n",
+       "       [0., 3.],\n",
+       "       [3., 3.]])"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "poly.coords"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "We can check wether a given point is _inside_ the polygon (a negative sign means outside, positive means inside):"
    ]
   },

--- a/src/polygon.cpp
+++ b/src/polygon.cpp
@@ -56,6 +56,18 @@ void init_polygon(py::module &m) {
         .def_property_readonly("edges", [](Polygon_2& s) {
             return py::make_iterator(s.edges_begin(), s.edges_end()); 
         }, py::keep_alive<0, 1>())
+        .def_property_readonly("coords", [](Polygon_2& s) {
+            py::array_t<double, py::array::c_style> coords;
+            coords.resize({s.size(), size_t(2)});
+            auto r = coords.mutable_unchecked<2>();
+            size_t i = 0;
+            for (auto v = s.vertices_begin(); v != s.vertices_end(); v++, i++) {
+                r(i, 0) = CGAL::to_double(v->x());
+                r(i, 1) = CGAL::to_double(v->y());
+            }
+            assert(i == s.size());
+            return coords;
+        })
     	.def("__len__", &Polygon_2::size)
     	.def("is_simple", &Polygon_2::is_simple)
     	.def("is_convex", &Polygon_2::is_convex)


### PR DESCRIPTION
This adds a convenience method to `Polygon` to return all coordinates in a single numpy array.

At the moment, to get those coordinates as float is a bit clumsy, e.g.:
`numpy.array([(float(v.x()), float(v.y())) for v in polygon.vertices])`

Not only do you need to access via `.x()` and `.y()` you also need to cast the returned numbers into `float` since they are number classes.

For interacting with other libraries like <a href="https://shapely.readthedocs.io/en/stable/manual.html">shapely</a> however you just need a list of double coordinates.

The name `coords` is taken from shapely.