### PR TITLE
Add vectorized on_side to polygon

### DIFF
--- a/src/polygon.cpp
+++ b/src/polygon.cpp
@@ -16,8 +16,12 @@ std::vector<Segment_2> get_edges(Polygon_2 p) {
 	return result;
 }
 
-CGAL::Bounded_side on_side(Polygon_2& poly, Point_2& point) {
+CGAL::Bounded_side on_side(Polygon_2& poly, const Point_2& point) {
     return CGAL::bounded_side_2(poly.vertices_begin(), poly.vertices_end(), point, Kernel());
+}
+
+CGAL::Bounded_side on_side(Polygon_2& poly, const double px, const double py) {
+    return CGAL::bounded_side_2(poly.vertices_begin(), poly.vertices_end(), Point_2(px, py), Kernel());
 }
 
 Point_2 centroid(Polygon_2& poly) {
@@ -76,6 +80,9 @@ void init_polygon(py::module &m) {
     	.def("bbox", &Polygon_2::bbox)
     	.def("area", &Polygon_2::area)
         .def("oriented_side", &Polygon_2::oriented_side)
+        .def("on_side", py::overload_cast<Polygon_2&, const Point_2&>(&on_side))
+        .def("on_side", py::overload_cast<Polygon_2&, const double, const double>(&on_side))
+        .def("on_side", py::vectorize(py::overload_cast<Polygon_2&, const double, const double>(&on_side)))
         .def("__repr__", &toString<Polygon_2>)
         .def("_ipython_display_", [](Polygon_2& s) {
             py::module::import("skgeom.draw").attr("draw_polygon")(


### PR DESCRIPTION
Adds a vectorized version of `on_side` to Polygon2 for efficiency (and allows for numpy array inputs/outputs).
Example:
```python
import numpy as np
import skgeom
p = skgeom.random_polygon()
print(p.on_side(*np.random.uniform(-0.3, 0.3, size=(2, 10))))
```
Output:
```python
array([ 1,  1,  1,  1,  1, -1,  1,  1,  1, -1], dtype=int32)
```

Happy to add tests (for this function as well as for polygon in general) although I was a little confused with the structure of the tests!
