### PR TITLE
Add numpy interface to convex hull function

### DIFF
--- a/src/convex_hull.cpp
+++ b/src/convex_hull.cpp
@@ -1,5 +1,8 @@
 #include "skgeom.hpp"
 #include "funcs.hpp"
+
+#include <pybind11/numpy.h>
+
 #include <CGAL/ch_graham_andrew.h>
 
 void init_convex_hull(py::module &m) {
@@ -8,6 +11,21 @@ void init_convex_hull(py::module &m) {
 	sub.def("graham_andrew", [](const std::vector<Point_2> & in) -> std::vector<Point_2> {
 		std::vector<Point_2> out;
 		CGAL::ch_graham_andrew(in.begin(), in.end(), std::back_inserter(out));
+		return out;
+	});
+	sub.def("graham_andrew", [](const py::array_t<double>& in) -> std::vector<Point_2> {
+		std::vector<Point_2> in_pts;
+		std::vector<Point_2> out;
+		auto r = in.unchecked<2>();
+		if (r.shape(1) != 2) {
+			throw std::runtime_error("points array needs to be 2 dimensional");
+		}
+		const ssize_t n = r.shape(0);
+
+		for (ssize_t i = 0; i < n; i++) {
+			in_pts.push_back(Point_2(r(i, 0), r(i, 1)));
+		}
+		CGAL::ch_graham_andrew(in_pts.begin(), in_pts.end(), std::back_inserter(out));
 		return out;
 	});
 }


### PR DESCRIPTION
Allows user to specify input to `skgeom.convex_hull.graham_andrew` as a 2D numpy array of shape `(n, 2)` in addition to a list of points. Also results in a decent speedup over looping in Python to create a list of points:

```python
In [1]: import numpy as np

In [2]: import skgeom

In [3]: %timeit skgeom.convex_hull.graham_andrew(np.random.uniform(0, 1, size=(10000, 2)))
2.22 ms ± 14.4 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)

In [7]: %timeit skgeom.convex_hull.graham_andrew([skgeom.Point2(*pt) for pt in np.random.uniform(0, 1, size=(10000, 2))])
15.2 ms ± 132 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```

Feel free to merge if it is useful!