### PR TITLE
Polyhedron_3 to Polyhedron3

### DIFF
--- a/src/docs/docs_polyhedron.h
+++ b/src/docs/docs_polyhedron.h
@@ -23,10 +23,10 @@
 // doc of Polyhedron_3 class
 //=======================================================
 const char* Polyhedron_3_doc = "\
-	A polyhedral surface Polyhedron_3 consists of vertices V, edges E,\n\
+	A polyhedral surface Polyhedron3 consists of vertices V, edges E,\n\
 	facets F and an incidence relation on them.\n\
 	Creation:\n\
-	P = Polyhedron_3()\n\
+	P = Polyhedron3()\n\
 	the C++ documentation contains the wide explication of this class:\n\
 	http://www.cgal.org/Manual/3.2/doc_html/cgal_manual/Polyhedron_ref/Class_Polyhedron_3.html";
 

--- a/src/polyhedron.cpp
+++ b/src/polyhedron.cpp
@@ -57,7 +57,7 @@ void init_polyhedron(py::module &m) {
         .def("set_halfedge", &PolyhedronFacet::set_halfedge)
     ;
 
-    py::class_<Polyhedron_3>(m, "Polyhedron_3", Polyhedron_3_doc)
+    py::class_<Polyhedron_3>(m, "Polyhedron3", Polyhedron_3_doc)
         .def(py::init<>())
         .def(py::init<Polyhedron_3>())
         // .def(init<size_t, size_t, size_t, optional<const kernel&>>())


### PR DESCRIPTION
Addresses #65.
All other python classes do not have underscores so this brings the Polyhedron class into compliance with that style. Does break compatibility with previous versions but may not be a big deal?