### PR TITLE
fix: Fix setup.py for modern homebrew/macOS and CGAL

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,8 @@ if conda_prefix:
         include_dirs.append(os.path.join(conda_prefix, 'Library', 'include'))
 elif os.path.exists('/usr/include/CGAL/'):
     cgal_include = '/usr/include/CGAL/'
+elif os.path.exists('/opt/homebrew/include/CGAL/'):
+    cgal_include = '/opt/homebrew/include/CGAL/'
 else:
     cgal_include = '/usr/local/include/CGAL/'
 
@@ -97,7 +99,10 @@ if conda_prefix:
     if cgal_version < (5, 0):
         include_dirs.insert(1, os.path.join(prefix, 'include'))
 
-if sys.platform == 'darwin' and glob.glob('/usr/local/lib/libboost*-mt*'):
+if sys.platform == 'darwin' and (
+    glob.glob('/usr/local/lib/libboost*-mt*') +
+    glob.glob('/opt/homebrew/lib/libboost*-mt*')
+):
     boost_mt = True
 else:
     boost_mt = False

--- a/setup.py
+++ b/setup.py
@@ -25,8 +25,9 @@ include_dirs = [
     get_pybind_include(user=True),
 ]
 
-library_dirs = None
+library_dirs = []
 cgal_libs = ["CGAL", "CGAL_Core"]
+boost_mt = False
 
 conda_prefix = os.getenv('CONDA_PREFIX')
 if not conda_prefix:
@@ -99,13 +100,13 @@ if conda_prefix:
     if cgal_version < (5, 0):
         include_dirs.insert(1, os.path.join(prefix, 'include'))
 
-if sys.platform == 'darwin' and (
-    glob.glob('/usr/local/lib/libboost*-mt*') +
-    glob.glob('/opt/homebrew/lib/libboost*-mt*')
-):
-    boost_mt = True
-else:
-    boost_mt = False
+if sys.platform == 'darwin':
+    boost_mt = bool(
+        glob.glob('/usr/local/lib/libboost*-mt*') +
+        glob.glob('/opt/homebrew/lib/libboost*-mt*')
+    )
+    include_dirs += ['/usr/local/include', '/opt/homebrew/include']
+    library_dirs += ['/usr/local/lib', '/opt/homebrew/lib']
 
 ext_modules = [
     Extension(

--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -672,7 +672,9 @@ void init_skgeom_kernel(py::module &m) {
     m.def("do_intersect", &do_intersect<Line_3, Line_3>);
     m.def("do_intersect", &do_intersect<Line_3, Plane_3>);
     m.def("do_intersect", &do_intersect<Line_3, Ray_3>);
-    //m.def("do_intersect", &do_intersect<Line_3, Segment_3>); // <-- THIS ONE ERRORS ON OS-X, windows (VS) & linux work fine
+#ifndef __APPLE__
+    m.def("do_intersect", &do_intersect<Line_3, Segment_3>); // <-- THIS ONE ERRORS ON OS-X, windows (VS) & linux work fine
+#endif
     m.def("do_intersect", &do_intersect<Line_3, Triangle_3>);
 
     m.def("do_intersect", &do_intersect<Plane_3, Plane_3>);
@@ -683,10 +685,14 @@ void init_skgeom_kernel(py::module &m) {
 
     
     m.def("do_intersect", &do_intersect<Ray_3, Ray_3>);
-    //m.def("do_intersect", &do_intersect<Ray_3, Segment_3>); // <-- THIS ONE ERRORS ON OS-X, windows (VS) & linux work fine
+#ifndef __APPLE__
+    m.def("do_intersect", &do_intersect<Ray_3, Segment_3>); // <-- THIS ONE ERRORS ON OS-X, windows (VS) & linux work fine
+#endif
     m.def("do_intersect", &do_intersect<Ray_3, Triangle_3>);
 
-    // m.def("do_intersect", &do_intersect<Segment_3, Segment_3>); // <-- THIS ONE ERRORS ON OS-X, windows (VS) & linux work fine
+#ifndef __APPLE__
+    m.def("do_intersect", &do_intersect<Segment_3, Segment_3>); // <-- THIS ONE ERRORS ON OS-X, windows (VS) & linux work fine
+#endif
     
     m.def("do_intersect", &do_intersect<Segment_3, Triangle_3>);
     m.def("do_intersect", &do_intersect<Sphere_3, Sphere_3>);

--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -346,16 +346,16 @@ void init_skgeom_kernel(py::module &m) {
         .def("__repr__", &toString<Transformation_2>)
     ;
 
-    // =====================================================================================
-    //
-    //            ____  _____ 
-    //           |___ \|  __ \ 
-    //             __) | |  | |
-    //            |__ <| |  | |
-    //            ___) | |__| |
-    //           |____/|_____/ 
-    //
-    // =====================================================================================
+    /* ===================================================================================== *\
+    ||                                                                                       ||
+    ||                                    ____  _____                                        ||
+    ||                                   |___ \|  __ \                                       ||
+    ||                                     __) | |  | |                                      ||
+    ||                                    |__ <| |  | |                                      ||
+    ||                                    ___) | |__| |                                      ||
+    ||                                   |____/|_____/                                       ||
+    ||                                                                                       ||
+    \* ===================================================================================== */
 
 
     py::class_<Aff_transformation_3>(m, "Transformation3")
@@ -672,7 +672,7 @@ void init_skgeom_kernel(py::module &m) {
     m.def("do_intersect", &do_intersect<Line_3, Line_3>);
     m.def("do_intersect", &do_intersect<Line_3, Plane_3>);
     m.def("do_intersect", &do_intersect<Line_3, Ray_3>);
-    //m.def("do_intersect", &do_intersect<Line_3, Segment_3>); <-- THIS ONE ERRORS ON OS-X, windows (VS) & linux work fine
+    //m.def("do_intersect", &do_intersect<Line_3, Segment_3>); // <-- THIS ONE ERRORS ON OS-X, windows (VS) & linux work fine
     m.def("do_intersect", &do_intersect<Line_3, Triangle_3>);
 
     m.def("do_intersect", &do_intersect<Plane_3, Plane_3>);
@@ -683,10 +683,10 @@ void init_skgeom_kernel(py::module &m) {
 
     
     m.def("do_intersect", &do_intersect<Ray_3, Ray_3>);
-    //m.def("do_intersect", &do_intersect<Ray_3, Segment_3>);  <-- THIS ONE ERRORS ON OS-X, windows (VS) & linux work fine
+    //m.def("do_intersect", &do_intersect<Ray_3, Segment_3>); // <-- THIS ONE ERRORS ON OS-X, windows (VS) & linux work fine
     m.def("do_intersect", &do_intersect<Ray_3, Triangle_3>);
 
-    m.def("do_intersect", &do_intersect<Segment_3, Segment_3>);
+    // m.def("do_intersect", &do_intersect<Segment_3, Segment_3>); // <-- THIS ONE ERRORS ON OS-X, windows (VS) & linux work fine
     
     m.def("do_intersect", &do_intersect<Segment_3, Triangle_3>);
     m.def("do_intersect", &do_intersect<Sphere_3, Sphere_3>);


### PR DESCRIPTION
Fixes #87

The setup.py had some sensitivity for homebrew installs that use the old
homebrew root /usr/local. However, modern installations of homebrew use
/opt/homebrew instead. This commit makes the build able to detect CGAL and
boost when installed via homebrew in the new path.