### PR TITLE
Allow prescribed kernel in different modules, fix #62

### DIFF
--- a/include/skgeom.hpp
+++ b/include/skgeom.hpp
@@ -22,9 +22,7 @@
 
 namespace py = pybind11;
 
-#if ((CGAL_VERSION_MAJOR >= 5) && (CGAL_VERSION_MINOR >= 2)) || (CGAL_VERSION_MAJOR > 5)
-typedef CGAL::Exact_predicates_inexact_constructions_kernel Kernel;
-#else
+#ifndef KERNEL_PRESCRIBED
 typedef CGAL::Exact_predicates_exact_constructions_kernel   Kernel;
 #endif
 

--- a/src/arrangement.cpp
+++ b/src/arrangement.cpp
@@ -1,11 +1,14 @@
-#include "skgeom.hpp"
-#include "funcs.hpp"
-
 #include <CGAL/Rotational_sweep_visibility_2.h>
 #include <CGAL/Arr_segment_traits_2.h>
 #include <CGAL/Arrangement_2.h>
 #include <CGAL/CORE_algebraic_number_traits.h>
 #include <CGAL/Arr_Bezier_curve_traits_2.h>
+
+typedef CGAL::Exact_predicates_exact_constructions_kernel   Kernel;
+#define KERNEL_PRESCRIBED
+
+#include "skgeom.hpp"
+#include "funcs.hpp"
 
 typedef Segment_Arrangement_2::Ccb_halfedge_circulator          Ccb_halfedge_circulator;
 typedef Segment_Arrangement_2::Isolated_vertex_iterator         Isolated_vertex_iterator;

--- a/src/skeleton.cpp
+++ b/src/skeleton.cpp
@@ -1,8 +1,9 @@
-#include "skgeom.hpp"
-
 #include <CGAL/create_straight_skeleton_2.h>
 #include <CGAL/create_straight_skeleton_from_polygon_with_holes_2.h>
 #include <CGAL/create_offset_polygons_2.h>
+
+typedef CGAL::Exact_predicates_inexact_constructions_kernel   Kernel;
+#define KERNEL_PRESCRIBED
 
 typedef CGAL::Straight_skeleton_2<Kernel> Skeleton_2;
 typedef std::shared_ptr<Skeleton_2>       Skeleton_2_Ref;
@@ -14,6 +15,8 @@ typedef Skeleton_2::Face_const_iterator FaceConstIterator;
 typedef CGAL::HalfedgeDS_in_place_list_vertex<Skeleton_2::Vertex> Skeleton_2_Vertex;
 typedef CGAL::HalfedgeDS_in_place_list_halfedge<Skeleton_2::Halfedge> Skeleton_2_Halfedge;
 typedef CGAL::HalfedgeDS_in_place_list_face<Skeleton_2::Face> Skeleton_2_Face;
+
+#include "skgeom.hpp"
 
 template<typename T>
 std::shared_ptr<T> to_std(boost::shared_ptr<T> ptr) {


### PR DESCRIPTION
Different modules sometimes only work well only with exact or inexact
kernel, but not both of them.