### PR TITLE
Add installation instructions for Ubuntu 18.04 and 20.04+

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,62 @@ The docs are hosted on github: [https://scikit-geometry.github.io/scikit-geometr
 
 It is built from Jupyter notebooks that can be found under the `/docs` subdirectory.
 
+## Installation
+
+### Conda
+
+The package is published for Linux, OS X and Windows to the `conda-forge` channel. Users of conda can simply install via:
+
+```
+conda install scikit-geometry -c conda-forge
+```
+
+### Building from source
+
+For users who use other package managers, the package has to be built from source. Therefore the dependencies for `CGAL` and `boost` have to be installed or updated:
+
+#### Ubuntu 20.04+
+
+```
+sudo apt-get install cgal-dev libboost-all-dev
+pip install -e . -v  # takes few minutes, grab a coffee ...
+```
+
+#### Ubuntu 18.04 (bionic)
+
+Unfortunately, the Ubuntu packages for `CGAL` and `boost` are outdated. Thus the sources have to be downloaded separately (i.e. without `apt-get`):
+
+1. For `CGAL`, download the [CGAL-5.4.tar.xz](https://github.com/CGAL/cgal/releases/download/v5.4/CGAL-5.4.tar.xz) archive and unpack it.
+2. For `boost`, download the [boost_1_79_0.tar.gz](https://boostorg.jfrog.io/artifactory/main/release/1.79.0/source/boost_1_79_0.tar.gz) archive and unpack it.
+
+Adjust the `setup.py` to following:
+
+```python
+# ...
+include_dirs = [
+    "./include/",
+    "./src/docs/",
+    "<download-path>/CGAL-5.4/include/",  # <- NEW
+    "<download-path>/boost_1_79_0/",  ,  # <- NEW
+    # Path to pybind11 headers
+    get_pybind_include(),
+    get_pybind_include(user=True),
+]
+# ...
+```
+
+Finally you can start the installation: 
+
+```
+pip install -e . -v
+```
+
+To make sure the installation was successful run:
+
+```
+echo -e "import skgeom; print(skgeom.Point2(0, 5))" | python
+```
+
 ## License
 
 This software is licensed under the LGPL-3 license. See the [LICENSE](LICENSE) file for details.


### PR DESCRIPTION
Add installation instructions for Ubuntu 18.04 and 20.04+.

Especially the Ubuntu installation 18.04 is non trivial, since the packages for [CGAL](https://packages.ubuntu.com/search?keywords=cgal) and [boost ](https://packages.ubuntu.com/search?suite=default&section=all&arch=any&keywords=libboost-all-dev&searchon=names) (CGAL includes it) are outdated.

We can further use this info to create `manylinux` builds in the future.