### PR TITLE
Ensure ssize_t is defined when using MSVC on Windows

### DIFF
--- a/include/skgeom.hpp
+++ b/include/skgeom.hpp
@@ -1,4 +1,11 @@
 #pragma once
+
+// when building with MSVC ssize_t is not available
+#if defined(_MSC_VER)
+#include <BaseTsd.h>
+typedef SSIZE_T ssize_t;
+#endif
+
 #include <CGAL/Exact_predicates_exact_constructions_kernel.h>
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 #include <CGAL/intersections.h>


### PR DESCRIPTION
When building on Windows there are errors that `ssize_t` is undefined (in polygon.cpp and convex_hull.cpp).
As per https://stackoverflow.com/questions/22265610/why-ssize-t-in-visual-studio-2010-is-defined-as-unsigned ssize_t is not standard C, it is a typedef from Posix. 
This update gets the builds working on MSVC. 