### PR TITLE
Ensure pybind11 is correct version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -229,8 +229,8 @@ setup(
     description='scikit-geometry, the python computational geometry library',
     long_description='',
     ext_modules=ext_modules,
-    install_requires=['pybind11>=2.3,<2.8', 'numpy'],
-    setup_requires=['pybind11>=2.3,<2.8'],
+    install_requires=['pybind11>=2.8', 'numpy'],
+    setup_requires=['pybind11>=2.8'],
     extras_require={
         "drawing": ["matplotlib"],
     },


### PR DESCRIPTION
With #84 the older pybind11 version 2.7 no longer builds. This ensures a minimum of 2.8 is required. 

Otherwise errors such as the following are thrown:

```
        src/arrangement.cpp: In function ‘pybind11::iterator skgeom::make_handle_iterator(Iterator, Sentinel, Extra&& ...)’:
        src/arrangement.cpp:104:21: error: ‘iterator_access’ is not a member of ‘pybind11::detail’
          104 |             detail::iterator_access<Iterator>, Policy, Iterator, Sentinel, ValueType
```